### PR TITLE
tl-gen: Use original param name instead of rustified name

### DIFF
--- a/tdlib-tl-gen/src/functions.rs
+++ b/tdlib-tl-gen/src/functions.rs
@@ -93,7 +93,8 @@ fn write_function<W: Write>(
 
         writeln!(
             file,
-            "            \"{0}\": {0},",
+            "            \"{0}\": {1},",
+            param.name,
             rustifier::parameters::attr_name(param),
         )?;
     }


### PR DESCRIPTION
It causing an issues when rustified version of param is differ then original one (type in set_auto_download_settings).